### PR TITLE
Cleaned up the EC Read function and added a loop to both the Read and…

### DIFF
--- a/TPFanControl/portio.cpp
+++ b/TPFanControl/portio.cpp
@@ -60,42 +60,49 @@ logbuf[8192]= "";
 int FANCONTROL::ReadByteFromEC(int offset, char *pdata)
 {
 char data= -1;
-char data2= -1;
 int iOK = false;
 int iTimeout = 100;
 int iTimeoutBuf = 1000;
 int	iTime= 0;
 int iTick= 10;
+int numSetupTries = 50;
 
-for (iTime = 0; iTime < iTimeoutBuf; iTime+= iTick) {	// wait for full buffers to clear
-	data = (char)ReadPort(EC_CTRLPORT) & 0xff;			// or timeout iTimeoutBuf = 1000
-	if ( !(data & (EC_STAT_IBF | EC_STAT_OBF)) ) break;
-	::Sleep(iTick);}
+while (numSetupTries > 0) {
 
-if (data & EC_STAT_OBF) data2 = (char)ReadPort(EC_DATAPORT); //clear OBF if full
+	for (iTime = 0; iTime < iTimeoutBuf; iTime+= iTick) {	// wait for full buffers to clear
+		data = (char)ReadPort(EC_CTRLPORT) & 0xff;			// or timeout iTimeoutBuf = 1000
+		if ( !(data & (EC_STAT_IBF | EC_STAT_OBF)) ) break;
+		::Sleep(iTick);}
 
-WritePort(EC_CTRLPORT, EC_CTRLPORT_READ);			// tell 'em we want to "READ"
+	WritePort(EC_CTRLPORT, EC_CTRLPORT_READ);			// tell 'em we want to "READ"
 
-for (iTime = 0; iTime < iTimeout; iTime += iTick) {	// wait for IBF and OBF to clear
-	data = (char)ReadPort(EC_CTRLPORT) & 0xff;
-	if ( !(data & (EC_STAT_IBF | EC_STAT_OBF)) ) {
-		iOK= true;
-		break;}
-	::Sleep(iTick);} // try again after a moment
-
-if (!iOK) return 0;
-iOK = false;
-
-WritePort(EC_DATAPORT, offset);						// tell 'em where we want to read from
-
-if ( !(data & EC_STAT_OBF) ) {
-	for (iTime= 0; iTime<iTimeout; iTime+= iTick) { // wait for OBF 
+	for (iTime = 0; iTime < iTimeout; iTime += iTick) {	// wait for IBF and OBF to clear
 		data = (char)ReadPort(EC_CTRLPORT) & 0xff;
-		if ( (data & EC_STAT_OBF) ) {
+		if ( !(data & (EC_STAT_IBF | EC_STAT_OBF)) ) {
 			iOK= true;
 			break;}
-		::Sleep(iTick);}							// try again after a moment
-	if (!iOK) return 0;}
+		::Sleep(iTick);} // check again after a moment
+
+	if (!iOK) return 0;
+	iOK = false;
+
+	WritePort(EC_DATAPORT, offset);						// tell 'em where we want to read from
+
+	for (iTime = 0; iTime < iTimeout; iTime += iTick) { // wait for OBF 
+		data = (char)ReadPort(EC_CTRLPORT) & 0xff;
+		if ((data & EC_STAT_OBF)) {
+			iOK = true;
+			numSetupTries = 1;
+			break;
+		}
+		::Sleep(iTick); // check again after a moment
+	}
+	
+	// decrement counter. If greater than 0 afterwards,
+	// start the read process over again
+	numSetupTries -= 1;
+}
+	if (!iOK) return 0;
 
 *pdata = ReadPort(EC_DATAPORT);
 
@@ -117,47 +124,58 @@ int iTimeout = 100;
 int iTimeoutBuf = 1000;
 int	iTime= 0;
 int iTick= 10;
+int numSetupTries = 5;
 
-for (iTime = 0; iTime < iTimeoutBuf; iTime+= iTick) {	// wait for full buffers to clear
-	data = (char)ReadPort(EC_CTRLPORT) & 0xff;			// or timeout iTimeoutBuf = 1000
-	if ( !(data & (EC_STAT_IBF | EC_STAT_OBF)) ) break;
-	::Sleep(iTick);}
+while (numSetupTries > 0) {
 
-if (data & EC_STAT_OBF) data2 = (char)ReadPort(EC_DATAPORT); //clear OBF if full
+	for (iTime = 0; iTime < iTimeoutBuf; iTime += iTick) {	// wait for full buffers to clear
+		data = (char)ReadPort(EC_CTRLPORT) & 0xff;			// or timeout iTimeoutBuf = 1000
+		if (!(data & (EC_STAT_IBF | EC_STAT_OBF))) break;
+		::Sleep(iTick);
+	}
 
-for (iTime= 0; iTime<iTimeout; iTime+= iTick) { // wait for IOBF to clear
-	data = (char)ReadPort(EC_CTRLPORT) & 0xff;	
-	if ( !(data & EC_STAT_OBF) ) {
-		iOK= true;
-		break;}
-	::Sleep(iTick);}  // try again after a moment
+	if (data & EC_STAT_OBF) data2 = (char)ReadPort(EC_DATAPORT); //clear OBF if full
 
+	for (iTime = 0; iTime < iTimeout; iTime += iTick) { // wait for IOBF to clear
+		data = (char)ReadPort(EC_CTRLPORT) & 0xff;
+		if (!(data & EC_STAT_OBF)) {
+			iOK = true;
+			break;
+		}
+		::Sleep(iTick);
+	}  // try again after a moment
+
+	if (!iOK) return 0;
+	iOK = false;
+
+	WritePort(EC_CTRLPORT, EC_CTRLPORT_WRITE);		// tell 'em we want to "WRITE"
+
+	for (iTime = 0; iTime < iTimeout; iTime += iTick) { // wait for IBF and OBF to clear
+		data = (char)ReadPort(EC_CTRLPORT) & 0xff;
+		if (!(data & (EC_STAT_IBF | EC_STAT_OBF))) {
+			iOK = true;
+			break;
+		}
+		::Sleep(iTick);
+	}							// try again after a moment
+
+	if (!iOK) return 0;
+	iOK = false;
+
+	WritePort(EC_DATAPORT, offset);					// tell 'em where we want to write to
+
+	for (iTime = 0; iTime < iTimeout; iTime += iTick) { // wait for IBF and OBF to clear
+		data = (char)ReadPort(EC_CTRLPORT) & 0xff;
+		if (!(data & (EC_STAT_IBF | EC_STAT_OBF))) {
+			iOK = true;
+			numSetupTries = 1;
+			break;
+		}
+		::Sleep(iTick);
+	}							// try again after a moment
+	numSetupTries -= 1;
+}
 if (!iOK) return 0;
-iOK = false;
-
-WritePort(EC_CTRLPORT, EC_CTRLPORT_WRITE);		// tell 'em we want to "WRITE"
-
-for (iTime= 0; iTime<iTimeout; iTime+= iTick) { // wait for IBF and OBF to clear
-	data = (char)ReadPort(EC_CTRLPORT) & 0xff;
-	if ( !(data & (EC_STAT_IBF | EC_STAT_OBF)) ) {
-		iOK= true;
-		break;}
-	::Sleep(iTick);}							// try again after a moment
- 
-if (!iOK) return 0;
-iOK = false;
-
-WritePort(EC_DATAPORT, offset);					// tell 'em where we want to write to
-
-for (iTime= 0; iTime<iTimeout; iTime+= iTick) { // wait for IBF and OBF to clear
-	data = (char)ReadPort(EC_CTRLPORT) & 0xff;
-	if ( !(data & (EC_STAT_IBF | EC_STAT_OBF)) ) {
-		iOK= true;
-		break;}
-	::Sleep(iTick);}							// try again after a moment
- 
-if (!iOK) return 0;
-iOK = false;
 
 WritePort(EC_DATAPORT, NewData);				// tell 'em what we want to write there
 


### PR DESCRIPTION
… Write functions to immediately retry the whole EC Read/write setup process (clearing of EC I/O Buffers and requesting the I/O Action (read/write) and memory address) before giving up reading or writing data from the EC. This fixes the many EC read errors, hopefully adds a little robustness to the EC write proces, and keeps TPFanControl working properly even during heavy CPU load.